### PR TITLE
Feat/plan sign pet

### DIFF
--- a/alembic/versions/6f8d7e0c1bec_create_pets_plan_pet_table.py
+++ b/alembic/versions/6f8d7e0c1bec_create_pets_plan_pet_table.py
@@ -19,8 +19,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    pass
+    op.create_table(
+        'pet_plan_pet',
+        sa.Column('id', sa.String, primary_key=True),
+        sa.Column('pet_id', sa.String, sa.ForeignKey('pets.id')),
+        sa.Column('plan_id', sa.String, sa.ForeignKey('pets_plan.id'))
+    )
 
 
 def downgrade() -> None:
-    pass
+    op.drop_table('pet_plan_pet')

--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.db.models.user import User
+from app.schemas.plan import PlanSignPetRequest, PlanSignPetResponse
+from app.services.auth_service import verify_token
+from app.services.plans_service import PlanService
+from app.services.user_service import check_permission
+from app.db.session import get_db
+
+router = APIRouter()
+
+@router.post("/sign_pet", response_model=PlanSignPetResponse, dependencies=[Depends(check_permission(required_role="plan_sign_pet_create"))])
+def sign_pet_to_plan(request: PlanSignPetRequest, db: Session = Depends(get_db), user: User = Depends(verify_token)):
+    plan_service = PlanService(db)
+    try:
+        result = plan_service.sign_pet_to_plan(user.id, request.pet_id, request.plan_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return result

--- a/app/db/models/associations.py
+++ b/app/db/models/associations.py
@@ -1,3 +1,4 @@
+from uuid import uuid4
 from sqlalchemy import Column, String, ForeignKey, Table
 from app.db.base_class import Base
 
@@ -19,4 +20,11 @@ role_policy = Table(
     "role_policy", Base.metadata,
     Column("role_id", String, ForeignKey("roles.id"), primary_key=True),
     Column("policy_id", String, ForeignKey("policies.id"), primary_key=True)
+)
+
+pet_plan_pet = Table(
+    "pet_plan_pet", Base.metadata,
+    Column("id", String, primary_key=True, default=lambda: str(uuid4())),
+    Column("pet_id", String, ForeignKey("pets.id"), nullable=False),
+    Column("plan_id", String, ForeignKey("pets_plan.id"), nullable=False)
 )

--- a/app/db/models/pet.py
+++ b/app/db/models/pet.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 from sqlalchemy import Column, String, ForeignKey, Float, INTEGER
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
+from app.db.models.associations import pet_plan_pet
 
 
 class Pet(Base):
@@ -15,3 +16,4 @@ class Pet(Base):
     owner_id = Column(String, ForeignKey("users.id"), nullable=False)
 
     owner = relationship("User", back_populates="pets")
+    plans = relationship('PetPlan', secondary=pet_plan_pet, back_populates='pets')

--- a/app/db/models/pet_plan.py
+++ b/app/db/models/pet_plan.py
@@ -1,6 +1,8 @@
 from sqlalchemy import INTEGER, Column, Float, String
+from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 from uuid import uuid4
+from app.db.models.associations import pet_plan_pet
 
 
 class PetPlan(Base):
@@ -10,3 +12,4 @@ class PetPlan(Base):
     name = Column(String, nullable=False, unique=True)
     max_pets = Column(INTEGER, nullable=False, unique=True)
     price = Column(Float, nullable=False, unique=True)
+    pets = relationship('Pet', secondary=pet_plan_pet, back_populates='plans')

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import users, auth, roles, groups, pets, pets_plan
+from app.api.v1.endpoints import users, auth, roles, groups, pets, pets_plan, plans
 
 from dotenv import load_dotenv
 import os
@@ -23,6 +23,7 @@ app.include_router(roles.router, prefix="/roles", tags=["roles"])
 app.include_router(groups.router, prefix="/groups", tags=["groups"])
 app.include_router(pets.router, prefix="/pets", tags=["pets"])
 app.include_router(pets_plan.router, prefix="/pets_plan", tags=["pets_plan"])
+app.include_router(plans.router, prefix="/plans", tags=["plans"])
 
 
 if __name__ == "__main__":

--- a/app/schemas/plan.py
+++ b/app/schemas/plan.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class PlanSignPetRequest(BaseModel):
+    pet_id: str
+    plan_id: str
+
+class PlanSignPetResponse(BaseModel):
+    message: str

--- a/app/services/plans_service.py
+++ b/app/services/plans_service.py
@@ -1,0 +1,45 @@
+from sqlalchemy.orm import Session
+from app.db.models.pet import Pet
+from app.db.models.pet_plan import PetPlan
+from app.db.models.associations import pet_plan_pet
+from sqlalchemy import and_
+
+
+class PlanService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def sign_pet_to_plan(self, user_id: str, pet_id: str, plan_id: str):
+        pet_user = self.db.query(Pet).filter(and_(Pet.id == pet_id, Pet.owner_id == user_id)).first()
+        if not pet_user:
+            raise Exception("Pet not found or not owned by the user")
+
+        pet_plan = self.db.query(PetPlan).filter(PetPlan.id == plan_id).first()
+        if not pet_plan:
+            raise Exception("Plan not found")
+
+        pets_in_plan = self.db.query(pet_plan_pet).filter(pet_plan_pet.c.plan_id == plan_id).count()
+
+        if pets_in_plan >= pet_plan.max_pets:
+            raise Exception(f"Plan has reached its limit of {pet_plan.max_pets} pets.")
+
+        insert_pet_plan = pet_plan_pet.insert().values(pet_id=pet_id, plan_id=plan_id)
+        self.db.execute(insert_pet_plan)
+        self.db.commit()
+
+        return {"message": "Pet successfully signed to the plan."}
+
+    def cancel_pet_plan(self, user_id: str, pet_id: str, plan_id: str):
+        pet = self.db.query(Pet).filter(and_(Pet.id == pet_id, Pet.owner_id == user_id)).first()
+        if not pet:
+            raise Exception("Pet not found or not owned by the user")
+
+        remove_out_plan = pet_plan_pet.delete().where(and_(pet_plan_pet.c.pet_id == pet_id, pet_plan_pet.c.plan_id == plan_id))
+        result = self.db.execute(remove_out_plan)
+
+        if result.rowcount == 0:
+            raise Exception("No such association found between pet and plan.")
+
+        self.db.commit()
+
+        return {"message": "Plan cancelled for the pet."}

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,105 @@
+def test_sign_pet_to_plan_valid(client, token_with_role_client, token_with_role_admin, clear_db):
+    client_token = token_with_role_client
+    admin_token = token_with_role_admin
+
+    pet1 = client.post(
+        "/pets/",
+        json={"name": "Rex", "age": 2, "weight": 1.2, "species": "Dog"},
+        headers={"Authorization": f"Bearer {client_token}"}
+    )
+
+    pet1_id = pet1.json()["id"]
+
+    pet2 = client.post(
+        "/pets/",
+        json={"name": "Nina", "age": 2, "weight": 0.600, "species": "Cat"},
+        headers={"Authorization": f"Bearer {client_token}"}
+    )
+
+    pet2_id = pet2.json()["id"]
+
+    plan = client.post(
+        "/pets_plan/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Plan test", "max_pets": 2, "price": 10.0},
+    )
+
+    plan_id = plan.json()["id"]
+
+    response1 = client.post(
+        "/plans/sign_pet/",
+        headers={"Authorization": f"Bearer {client_token}"},
+        json={"pet_id": pet1_id, "plan_id": plan_id},
+    )
+
+    assert response1.status_code == 200
+    assert response1.json()["message"] == "Pet successfully signed to the plan."
+
+    response2 = client.post(
+        "/plans/sign_pet/",
+        headers={"Authorization": f"Bearer {client_token}"},
+        json={"pet_id": pet2_id, "plan_id": plan_id},
+    )
+
+    assert response2.status_code == 200
+    assert response2.json()["message"] == "Pet successfully signed to the plan."
+
+
+def test_sign_pet_to_plan_max_pets_exceeded(client, token_with_role_client, token_with_role_admin, clear_db):
+    client_token = token_with_role_client
+    admin_token = token_with_role_admin
+
+    pet1 = client.post(
+        "/pets/",
+        json={"name": "Rex", "age": 2, "weight": 1.2, "species": "Dog"},
+        headers={"Authorization": f"Bearer {client_token}"}
+    )
+
+    pet1_id = pet1.json()["id"]
+
+    pet2 = client.post(
+        "/pets/",
+        json={"name": "Nina", "age": 2, "weight": 0.600, "species": "Cat"},
+        headers={"Authorization": f"Bearer {client_token}"}
+    )
+
+    pet2_id = pet2.json()["id"]
+
+    pet3 = client.post(
+        "/pets/",
+        json={"name": "Nina", "age": 2, "weight": 0.600, "species": "Cat"},
+        headers={"Authorization": f"Bearer {client_token}"}
+    )
+
+    pet3_id = pet3.json()["id"]
+
+    plan = client.post(
+        "/pets_plan/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Plan test", "max_pets": 2, "price": 10.0},
+    )
+
+    plan_id = plan.json()["id"]
+    count_max = plan.json()["max_pets"]
+
+    client.post(
+        "/plans/sign_pet/",
+        headers={"Authorization": f"Bearer {client_token}"},
+        json={"pet_id": pet1_id, "plan_id": plan_id},
+    )
+
+    client.post(
+        "/plans/sign_pet/",
+        headers={"Authorization": f"Bearer {client_token}"},
+        json={"pet_id": pet2_id, "plan_id": plan_id},
+    )
+
+    response = client.post(
+        "/plans/sign_pet/",
+        headers={"Authorization": f"Bearer {client_token}"},
+        json={"pet_id": pet3_id, "plan_id": plan_id},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"Plan has reached its limit of {count_max} pets."
+


### PR DESCRIPTION
feat/plan_sign_pet

Implementa a funcionalidade de assinatura de pets a planos, com validação do limite de pets por plano e associando o pet apenas ao usuário logado. Adiciona as seguintes funcionalidades:

Modelos e relações N-N entre pets e planos
Validação de quantidade máxima de pets por plano
Endpoints e lógica no service
Casos de teste cobrindo todos os cenários
Tags adicionadas ao README:

#CRUD - Planos e Pets
#Validação - Limite de pets por plano
#Tests - Cobertura de casos